### PR TITLE
Accept existing category field on import

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -138,10 +138,21 @@ def uploadFiles():
 
     asdd = pd.read_csv(tmp_name, sep=sep)
     asdd.drop(asdd.filter(regex="Unname"),axis=1, inplace=True)
+
+    if "Kategorie" in asdd:
+        df_y = pd.DataFrame(asdd, columns=['Kategorie']).values.tolist()
+        df_y_flat = list(dict.fromkeys( [subitem for item in df_y for subitem in item] ))
+        y_existing_str = asdd["Kategorie"]
+        asdd.drop(["Kategorie"], axis=1, inplace=True)
+    else:
+        df_y_flat = []
+        y_existing_str = []
+
     asdd.to_csv(tmp_name, index=False)
 
     return render_template('label.html', data={
-        "lable_predict_single": [],
+        "lable_predict": y_existing_str,
+        "lable_predict_single": [ e for e in df_y_flat],
         "data": load_csv(tmp_name)
     })
 

--- a/web/templates/label.html
+++ b/web/templates/label.html
@@ -168,7 +168,7 @@
                 <div class="element kat_col">
                     <select name="pred_kat" class="pred_kat" id="pred_kat_{{ outer_loop.index0 }}">
                         {% for dd in data['lable_predict_single'] %}
-                        <option value="{{ dd }}" >{{ dd }}</option>
+                        <option value="{{ dd }}" {% if dd == data['lable_predict'][outer_loop.index0] %} selected {% endif %} >{{ dd }}</option>
                         {% endfor %}
                     </select>
                 </div>


### PR DESCRIPTION
When importing a csv to create a new model, it would be useful if it would accept a CSV file prefilled with categories.